### PR TITLE
Add analysis script converting CustomerID to int

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# Explorative-Datenanalyse-eines-Online-Shops
+# Explorative Datenanalyse eines Online Shops
+
+Dieses Repository enthält Daten und Notebooks zur Analyse eines Online-Retail-Datensatzes.
+
+Zum schnellen Einstieg steht im Ordner `ecommerce-eda/scripts` das Python-Skript `summary.py` bereit.
+Es lädt die Daten, bereinigt sie und berechnet Kennzahlen wie den Gesamtumsatz und den durchschnittlichen Warenkorbwert.
+
+Das Skript kann direkt ausgeführt werden:
+
+```bash
+python ecommerce-eda/scripts/summary.py
+```
+
+Dabei wird auch die Kunden-ID korrekt als Ganzzahl behandelt. Dadurch erscheinen in Auswertungen keine Werte wie `17850.0`, sondern `17850`.

--- a/ecommerce-eda/scripts/summary.py
+++ b/ecommerce-eda/scripts/summary.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from pathlib import Path
+
+def load_data():
+    data_path = Path(__file__).resolve().parents[1] / "data" / "data.csv"
+    return pd.read_csv(data_path, encoding="latin1")
+
+
+def clean_data(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df = df[df["Quantity"] > 0]
+    df = df.dropna(subset=["CustomerID"])
+    df["CustomerID"] = df["CustomerID"].astype(int)
+    df["InvoiceDate"] = pd.to_datetime(df["InvoiceDate"])
+    df["TotalPrice"] = df["Quantity"] * df["UnitPrice"]
+    return df
+
+
+def main():
+    df = clean_data(load_data())
+    total_revenue = df["TotalPrice"].sum()
+    avg_basket = df.groupby("InvoiceNo")["TotalPrice"].sum().mean()
+    print(f"Total revenue: {total_revenue:.2f}")
+    print(f"Average basket value: {avg_basket:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small analysis script that loads the dataset and prints key metrics
- cast `CustomerID` to `int` during cleaning to avoid float IDs
- update README with instructions for the new script

## Testing
- `python ecommerce-eda/scripts/summary.py`
- `python -m py_compile ecommerce-eda/scripts/summary.py`


------
https://chatgpt.com/codex/tasks/task_e_683f471be1348323b0ed18107fbab2bb